### PR TITLE
Updated to 1.16.4 with BS-Hook 2.*.* hook macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ At any rate, let's say we want to replace the text on the main menu button that 
 #include "GlobalNamespace/MainMenuViewController.hpp"
 #include "HMUI/CurvedTextMeshPro.hpp"
 MAKE_HOOK_MATCH(MainMenuViewController_DidActivate, &GlobalNamespace::MainMenuViewController::DidActivate, void,
-  MainMenuViewController* self, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling
+  GlobalNamespace::MainMenuViewController* self, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling
 ) {
   MainMenuViewController_DidActivate(self, firstActivation, addedToHierarchy, screenSystemEnabling);
   auto solo_button = UnityEngine::GameObject::Find(il2cpp_utils::createcsstr("SoloButton"));

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Most of the information you'll need to experiment with these elements lives in t
 
 To create a simple mod settings menu, all you need is a `DidActivate` function matching the signature [`void DidActivate(HMUI::ViewController* self, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling)`](https://github.com/darknight1050/questui/blob/master/shared/QuestUI.hpp#L25). When `firstActivation` is true, you can add your UI elements onto the ViewController. Finally, in your mod's `load()`, register it with QuestUI by calling `QuestUI::Register::RegisterModSettingsViewController<T*>(modInfo)`, and a button will be added to the Mod Settings menu.
 
-To create a more complex mod settings menu, you'll need to make a Custom Type extending `HMUI::ViewController` and overriding the `DidActivate` method to add your UI elements. After registering the custom type, call `QuestUI::Register::RegisterModSettingsViewController<T>(modInfo)`,
+To create a more complex mod settings menu, you'll need to make a Custom Type extending `HMUI::ViewController` and overriding the `DidActivate` method to add your UI elements. After registering the custom type, call `QuestUI::Register::RegisterModSettingsViewController<T*>(modInfo)`,
 
 You can also create a _much_ more complex mod settings menu by making your own `HMUI::FlowCoordinator` (as well as corresponding ViewControllers), and registering that with `QuestUI::Register::RegisterModSettingsFlowCoordinator<T*>(modInfo)`.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Certain assumptions are made, like that you are at least vaguely familiar with s
 
 When in doubt, check out the [BSMG Discord #quest-mod-dev channel](https://discord.gg/beatsabermods), and try searching on Discord before asking questions. In addition, most mods posted on BSMG include their source code, and browsing through those sources is a great way to familiarize yourself with certain patterns and techniques.
 
-Last updated: 4 February 2021, Beat Saber 1.13.2
+Last updated: 6 August 2021, Beat Saber 1.16.4
 
 **Table of Contents**
 - [Prerequisites](#prerequisites)


### PR DESCRIPTION
Updated for the new Hook macros, in the examples MAKE_HOOK_MATCH is being used which is the recommended macro for use with codegen, though some parts of this will therefore no longer make sense as codegen will be required

- [ ] Should change il2cpp specific stuff with hooks
- [ ] Other Hook macros might want to be added as well
- [ ] Fix any mistakes that were made

**NOTE:** This has mostly the macros updated some explanations are not updated though and some sections need a full rewrite potentially